### PR TITLE
Fix turn management in DuelViewModel

### DIFF
--- a/ViewModels/DuelViewModel.cs
+++ b/ViewModels/DuelViewModel.cs
@@ -8,18 +8,29 @@ namespace CCGGame.ViewModels
         public Player Player1 { get; set; }
         public Player Player2 { get; set; }
         private DuelService duelService;
+        private bool isPlayer1Turn;
 
         public DuelViewModel()
         {
             Player1 = new Player("Player 1");
             Player2 = new Player("Player 2");
             duelService = new DuelService();
+            isPlayer1Turn = true;
         }
 
         public void PlayTurn(Card cardPlayed)
         {
-            duelService.ResolveTurn(Player1, cardPlayed, Player2);
-            // Alternar entre jugadores, manejar turno, etc.
+            if (isPlayer1Turn)
+            {
+                duelService.ResolveTurn(Player1, cardPlayed, Player2);
+            }
+            else
+            {
+                duelService.ResolveTurn(Player2, cardPlayed, Player1);
+            }
+
+            // Alternar entre jugadores
+            isPlayer1Turn = !isPlayer1Turn;
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix turn management so players alternate properly

## Testing
- `dotnet build --no-restore` *(fails: wasi-experimental workload missing)*

------
https://chatgpt.com/codex/tasks/task_e_68486fbf88cc832294a2155ad59ce7bd